### PR TITLE
Object.assign polyfill for IE 11+

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,8 @@ export interface PrintdOptions {
     headElements?: HTMLElement[]
     /** Specifies a custom document body elements */
     bodyElements?: HTMLElement[]
+
+    [key: string]: undefined | HTMLElement | HTMLElement[]
 }
 
 export interface PrintdCallbackArgs {
@@ -71,7 +73,12 @@ export default class Printd {
     private elCopy?: HTMLElement
 
     constructor (options?: PrintdOptions) {
-        this.opts = Object.assign(DEFAULT_OPTIONS, (options || {})) as Required<PrintdOptions>
+        // IE 11+ "Object.assign" polyfill
+        this.opts = [ options || {}, DEFAULT_OPTIONS ].reduce((a, b) => {
+            Object.keys(b).forEach((k) => (a[k] = b[k]))
+            return a
+        }, {}) as Required<PrintdOptions>
+
         this.iframe = createIFrame(this.opts.parent)
     }
 


### PR DESCRIPTION
Because `Object.assign` is not supported by IE 11. This PR fixes #11 introducing a polyfill.

