### PR TITLE
Fix browser's tab hang when printing URLs on latest Chrome 99.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
         "README.md",
         "LICENSE.md"
     ],
-    "bundlesize": [
-        {
+    "bundlesize": [{
             "path": "./index.js",
             "maxSize": "2KB"
         },
@@ -49,7 +48,8 @@
         "test:bundle": "yarn build && bundlesize",
         "test:watch": "env NODE_ENV=debug karma start",
         "lint": "tslint --format stylish --project tsconfig.json",
-        "sample": "parcel sample/index.html"
+        "sample": "parcel sample/index.html",
+        "sample-build": "parcel build sample/index.html && cp -r sample/base.css dist/"
     },
     "devDependencies": {
         "@types/jasmine": "3.6.9",

--- a/sample/index.html
+++ b/sample/index.html
@@ -2,69 +2,76 @@
 <html>
 
 <head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>Printd example app</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css">
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Printd example app</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css">
 
-  <link id="myStyle" href="./style.css" rel="stylesheet" type="text/css">
+    <link id="myStyle" href="./style.css" rel="stylesheet" type="text/css">
 
-  <style>
-    button {
-      background-color: #fff;
-      border: solid 2px peru;
-      border-radius: 5px;
-      color: peru;
-      font-size: 16pt;
-      font-weight: bold;
-      padding: 10px;
-      width: 200px;
-    }
-  </style>
+    <style>
+        button {
+            background-color: #fff;
+            border: solid 2px peru;
+            border-radius: 5px;
+            color: peru;
+            font-size: 16pt;
+            font-weight: bold;
+            padding: 10px;
+            width: 200px;
+            cursor: pointer;
+        }
+        
+        button:hover {
+            border-color: #008b8b;
+            background-color: #add8e6;
+            color: #000;
+        }
+    </style>
 </head>
 
 <body>
-  <h1>This is a page title</h1>
+    <h1>This is a page title</h1>
 
-  <hr>
-
-  <div id="myContent" class="img">
-    <h2>This is a content title</h2>
-    <p>Printing some <em>images</em> 🖼!</p>
-
-    <div>
-      <p>
-        <img src="https://c2.staticflickr.com/6/5632/21825222520_432fd1b183_k.jpg" alt="" width="200" height="200"> <br>
-
-        <code>Image 1: 200px X 200px</code>
-      </p>
-
-      <p>
-        <img src="https://c1.staticflickr.com/1/742/20508368953_9f318453e6_k.jpg?v" alt="" width="300" height="250">
-        <br>
-
-        <code>Image 2: 300px X 250px</code>
-      </p>
-    </div>
-
-    <p>
-      <button id="myButton1">🖨 Print element</button>
-      <button id="myButton2">🖨 Print URL</button>
-    </p>
-
-    <a href="https://github.com/joseluisq/printd">Printd repo link...</a>
-  </div>
-
-  <footer>
     <hr>
 
-    <p>
-      <em>This is a footer page...</em>
-    </p>
-  </footer>
+    <div id="myContent" class="img">
+        <h2>This is a content title</h2>
+        <p>Printing some <em>images</em> 🖼!</p>
 
-  <script src="index.ts"></script>
+        <div>
+            <p>
+                <img src="https://c2.staticflickr.com/6/5632/21825222520_432fd1b183_k.jpg" alt="" width="200" height="200"> <br>
+
+                <code>Image 1: 200px X 200px</code>
+            </p>
+
+            <p>
+                <img src="https://c1.staticflickr.com/1/742/20508368953_9f318453e6_k.jpg?v" alt="" width="300" height="250">
+                <br>
+
+                <code>Image 2: 300px X 250px</code>
+            </p>
+        </div>
+
+        <p>
+            <button id="myButton1">🖨 Print element</button>
+            <button id="myButton2">🖨 Print URL</button>
+        </p>
+
+        <a href="https://github.com/joseluisq/printd">Printd repo link...</a>
+    </div>
+
+    <footer>
+        <hr>
+
+        <p>
+            <em>This is a footer page...</em>
+        </p>
+    </footer>
+
+    <script src="index.ts"></script>
 </body>
 
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,8 +170,7 @@ export default class Printd {
     }
 
     private launchPrint (contentWindow: Window) {
-        const result = contentWindow.document.execCommand("print", false, undefined)
-        if (!result) {
+        if (!this.isLoading) {
             contentWindow.print()
         }
     }


### PR DESCRIPTION
This PR removes the printing call via [the deprecated API `execCommand`](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) and prefer the encouraged one [`Window API: print`](https://caniuse.com/mdn-api_window_print) call directly.

**Tested on**

- Chrome 99.0
- Safari 15.2
- Firefox 97/98
- IE 11 -> Thanks @ReynerHL and @jagDanJu for the tests

**Deprecation notice**

https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand

**References**

- https://caniuse.com/mdn-api_window_print
- https://caniuse.com/mdn-api_document_execcommand

Fixes #18

__How to test__

Run `yarn sample-build` to build the example assets then just serve the `dist/` generated directory with the assets using some web server.

For example you can use an [Static Web Server](https://github.com/joseluisq/static-web-server)
The just run:
```sh
static-web-server -d dist/ -p 1234 -g trace
```
Finally navigate to http://localhost:1234