### PR TITLE
Custom events support for browser `beforeprint` and `afterprint` events

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ d.printURL('http://127.0.0.1/', ({ launchPrint }) => {
 })
 ```
 
+### Built-in print events
+
+Printd provides convenient print event methods on top of the Browser `beforeprint` and `afterprint` events.
+However note that they *only* work when printing custom HTML elements via the `print()` method.
+
+```ts
+const d = new Printd()
+d.onBeforePrint((event) => console.log(event, "called before printing!"))
+d.onAfterPrint((event) => console.log(event, "called after printing!"))
+```
+
 ### getIFrame
 
 Gets the current `HTMLIFrameElement` reference.
@@ -232,4 +243,4 @@ Feel free to send some [Pull request](https://github.com/joseluisq/printd/pulls)
 ## License
 MIT license
 
-© 2017-present [José Quintana](https://git.io/joseluisq)
+© 2017-present [Jose Quintana](https://github.com/joseluisq)

--- a/sample/index.ts
+++ b/sample/index.ts
@@ -9,6 +9,10 @@ const d = new Printd({
     headElements: [ base ]
 })
 
+// Define some print events
+d.onBeforePrint(() => console.log("before print event!"))
+d.onAfterPrint(() => console.log("after print event!"))
+
 const content = document.getElementById("myContent")
 const btn1 = document.getElementById("myButton1")
 const btn2 = document.getElementById("myButton2")
@@ -39,8 +43,7 @@ function printElement () {
 
         // fire printing!
         launchPrint()
-    }
-  )
+    })
 }
 
 function printURL () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,8 @@ export default class Printd {
     private isLoading = false
     private hasEvents = false
     private callback?: PrintdCallback
+    private onbeforeprint?: (event: Event) => void
+    private onafterprint?: (event: Event) => void
     private elCopy?: HTMLElement
 
     constructor (options?: PrintdOptions) {
@@ -169,6 +171,26 @@ export default class Printd {
         this.iframe.src = url
     }
 
+    /**
+     * Add a browser `beforeprint` print event listener providing a custom callback.
+     *
+     * Note that it only works when printing custom HTML elements.
+     *
+     */
+    onBeforePrint (callback: (event: Event) => void) {
+        this.onbeforeprint = callback
+    }
+
+    /**
+     * Add a browser `afterprint` print event listener providing a custom callback.
+     *
+     * Note that it only works when printing custom HTML elements.
+     *
+     */
+    onAfterPrint (callback: (event: Event) => void) {
+        this.onafterprint = callback
+    }
+
     private launchPrint (contentWindow: Window) {
         if (!this.isLoading) {
             contentWindow.print()
@@ -179,6 +201,16 @@ export default class Printd {
         if (!this.hasEvents) {
             this.hasEvents = true
             this.iframe.addEventListener("load", () => this.onLoad(), false)
+
+            const { contentWindow } = this.iframe
+            if (contentWindow) {
+                if (this.onbeforeprint) {
+                    contentWindow.addEventListener("beforeprint", this.onbeforeprint)
+                }
+                if (this.onafterprint) {
+                    contentWindow.addEventListener("afterprint", this.onafterprint)
+                }
+            }
         }
     }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -71,7 +71,7 @@ describe("Printd test suite", () => {
         })
     })
 
-    describe("events", () => {
+    describe("browser events", () => {
         let printd: Printd
         let window: Window
         let spy: jasmine.Spy
@@ -106,6 +106,54 @@ describe("Printd test suite", () => {
             const [ type, args ] = spy.calls.argsFor(1)
 
             expect(type).toBe("afterprint")
+            expect(args).toEqual(onEvent)
+        })
+    })
+
+    describe("custom onBeforePrint event", () => {
+        let printd: Printd
+        let spy: jasmine.Spy
+
+        const onEvent = () => true
+
+        beforeEach(() => {
+            printd = new Printd()
+
+            spy = spyOn(printd, "onBeforePrint")
+            printd.onBeforePrint(onEvent)
+        })
+
+        it("should track all the arguments of its calls (onBeforePrint)", () => {
+            expect(printd.onBeforePrint).toHaveBeenCalledWith(onEvent)
+        })
+
+        it("should contain the given arguments (`onBeforePrint` event)", () => {
+            const [ args ] = spy.calls.argsFor(0)
+
+            expect(args).toEqual(onEvent)
+        })
+    })
+
+    describe("custom onAfterPrint event", () => {
+        let printd: Printd
+        let spy: jasmine.Spy
+
+        const onEvent = () => true
+
+        beforeEach(() => {
+            printd = new Printd()
+
+            spy = spyOn(printd, "onAfterPrint")
+            printd.onAfterPrint(onEvent)
+        })
+
+        it("should track all the arguments of its calls (onAfterPrint)", () => {
+            expect(printd.onAfterPrint).toHaveBeenCalledWith(onEvent)
+        })
+
+        it("should contain the given arguments (`onAfterPrint` event)", () => {
+            const [ args ] = spy.calls.argsFor(0)
+
             expect(args).toEqual(onEvent)
         })
     })


### PR DESCRIPTION
This PR adds support for listening to browser `beforeprint` and `afterprint` events via two new methods.
Note that those methods will *only* work when printing custom HTML elements via the `print()` method.

**API**

```ts
onBeforePrint (callback: (event: Event) => void)
onAfterPrint (callback: (event: Event) => void)
```

**Example**

```ts
const d = new Printd()

d.onBeforePrint((event) => console.log(event, "called before printing!"))
d.onAfterPrint((event) => console.log(event, "called after printing!"))

d.print(document.getElementById('myelement'))
```


Resolves #21
